### PR TITLE
Add way to access text editing and text input events

### DIFF
--- a/gamekit/input.zig
+++ b/gamekit/input.zig
@@ -133,8 +133,13 @@ pub const Input = struct {
     }
 
     /// slice is only valid for the current frame
-    pub fn textInput(self: Input) []const u8 {
-        return &self.text_input;
+    pub fn textEdit(self: Input) ?[]const u8 {
+        return self.text_edit orelse null;
+    }
+
+    /// slice is only valid for the current frame
+    pub fn textInput(self: Input) ?[]const u8 {
+        return self.text_input orelse null;
     }
 
     /// only true if down this frame and not down the previous frame


### PR DESCRIPTION
For this, I just added some 32 byte buffers and optional slices to point to them when a TextInput event or a TextEditing event is received. Downsides of this method: if more than one text editing/text input event is received per poll, then the first events will be missed.