### PR TITLE
update zig to latest

### DIFF
--- a/gamekit/deps/imgui/build.zig
+++ b/gamekit/deps/imgui/build.zig
@@ -67,6 +67,6 @@ pub fn getImGuiPackage(comptime prefix_path: []const u8) std.build.Pkg {
     if (prefix_path.len > 0 and !std.mem.endsWith(u8, prefix_path, "/")) @panic("prefix-path must end with '/' if it is not empty");
     return .{
         .name = "imgui",
-        .path = .{ .path = prefix_path ++ "gamekit/deps/imgui/imgui.zig" },
+        .source = .{ .path = prefix_path ++ "gamekit/deps/imgui/imgui.zig" },
     };
 }


### PR DESCRIPTION
``Pkg.path`` was renamed ``Pkg.source`` in commit https://github.com/ziglang/zig/commit/4e918873e7667e8d74b009cb34cbdd4df3305462