### PR TITLE
Window: ensure vsync is configured

### DIFF
--- a/gamekit/gamekit.zig
+++ b/gamekit/gamekit.zig
@@ -48,7 +48,6 @@ pub fn run(comptime config: Config) !void {
 
     renderkit.setup(.{
         .gl_loader = sdl.SDL_GL_GetProcAddress,
-        .disable_vsync = config.window.disable_vsync,
     }, std.heap.c_allocator);
 
     gfx.init();

--- a/gamekit/window.zig
+++ b/gamekit/window.zig
@@ -35,7 +35,7 @@ pub const Window = struct {
 
         window.createOpenGlWindow(config, flags);
 
-        if (config.disable_vsync) _ = sdl.SDL_GL_SetSwapInterval(0);
+        _ = sdl.SDL_GL_SetSwapInterval(if (config.disable_vsync) 0 else 1);
 
         window.id = sdl.SDL_GetWindowID(window.sdl_window);
         return window;


### PR DESCRIPTION
The default swap interval, at least on my M1 Mac, appears to be 0 (no vsync).  Ensure it's actually set when we want vsync.

This may or may not also fix the issue referred to here:

https://github.com/prime31/zig-gamekit/blob/19c8c9ca9aac9e9aba6809c4b06cf1a934515429/gamekit/time.zig#L179-L186

I also stop passing disable_vsync to renderkit, as it's unused.